### PR TITLE
fix checkbox top/bottom labelPlacement

### DIFF
--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -39,18 +39,18 @@
   }
 
   &.top {
-    &::after {
-      content: none;
-    }
-  }
-
-  &.bottom {
     &::before {
       content: none;
     }
 
     &::after {
       content: '';
+    }
+  }
+
+  &.bottom {
+    &::after {
+      content: none;
     }
   }
 }


### PR DESCRIPTION
I noticed the labelPlacement was inverted for top and bottom. 